### PR TITLE
mainthread: deprecate in favor of golang.design/x/runtime/mainthread

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,25 @@
-# mainthread [![PkgGoDev](https://pkg.go.dev/badge/golang.design/x/mainthread)](https://pkg.go.dev/golang.design/x/mainthread) ![mainthread](https://github.com/golang-design/mainthread/workflows/mainthread/badge.svg?branch=main) ![](https://changkun.de/urlstat?mode=github&repo=golang-design/mainthread)
+# mainthread
+
+> [!WARNING]
+> **This package has moved and this repository is archived.**
+>
+> `mainthread` now lives in the
+> [`golang.design/x/runtime`](https://github.com/golang-design/runtime)
+> module as [`golang.design/x/runtime/mainthread`](https://pkg.go.dev/golang.design/x/runtime/mainthread).
+> Update your imports:
+>
+> ```diff
+> -import "golang.design/x/mainthread"
+> +import "golang.design/x/runtime/mainthread"
+> ```
+>
+> The API is unchanged. This repository is no longer maintained; all
+> future development happens in `golang.design/x/runtime`.
 
 schedule functions to run on the main thread
 
 ```go
-import "golang.design/x/mainthread"
+import "golang.design/x/runtime/mainthread"
 ```
 
 ## Features

--- a/mainthread.go
+++ b/mainthread.go
@@ -73,6 +73,10 @@
 //
 // It is possible to cache up to a maximum of 42 panicked errors.
 // More errors are ignored.
+//
+// Deprecated: this package has moved to golang.design/x/runtime/mainthread.
+// Update imports to "golang.design/x/runtime/mainthread"; this repository
+// is no longer maintained and will be archived.
 package mainthread // import "golang.design/x/mainthread"
 
 import (


### PR DESCRIPTION
This package has moved into the `golang.design/x/runtime` module as
[`golang.design/x/runtime/mainthread`](https://pkg.go.dev/golang.design/x/runtime/mainthread)
(see golang-design/runtime#3), where it will be maintained alongside the
related runtime utilities.

This PR adds:
- a `Deprecated:` notice on the package doc (surfaced by pkg.go.dev and linters), and
- a prominent README banner directing users to the new import path.

The API is unchanged; migration is an import-path swap:

```diff
-import "golang.design/x/mainthread"
+import "golang.design/x/runtime/mainthread"
```

After merge, a final `mainthread` release carries this notice and the
repository is archived. golang.design/x/runtime is already released with
the mainthread subpackage (v0.2.0).